### PR TITLE
Makes chair breaking and door stuckage into weight dependant prefs

### DIFF
--- a/GainStation13/code/modules/client/preferences/preferences.dm
+++ b/GainStation13/code/modules/client/preferences/preferences.dm
@@ -19,8 +19,10 @@
 	var/blueberry_inflation = FALSE
 	///Extreme weight gain
 	var/weight_gain_extreme = FALSE
-	///stuckage
+	/// At what weight will you start to get stuck in airlocks?
 	var/stuckage = FALSE
+	/// At what weight will you start to break chairs?
+	var/chair_breakage = FALSE
 
 	// Helplessness, a set of prefs that make things extra tough at higher weights. If set to FALSE, they won't do anything.
 	///What fatness level disables movement?

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -12,7 +12,11 @@
 	if(!istype(L))
 		return ..()
 
-	if(L.fatness > 5000 && L.client?.prefs?.stuckage)
+	var/stuckage_weight = L?.client?.prefs?.stuckage
+	if(!stuckage_weight)
+		return ..() // They aren't able to get stuck
+	
+	if(L.fatness > (stuckage_weight * 2))
 		if(rand(1, 3) == 1)
 			L.doorstuck = 1
 			L.visible_message("<span class'danger'>[L] gets stuck in the doorway!</span>")
@@ -22,7 +26,7 @@
 			L.Knockdown(1)
 		return ..()
 
-	else if(L.fatness > 3000 && L.client?.prefs?.stuckage)
+	else if(L.fatness > stuckage_weight)
 		if(rand(1, 5) == 1)
 			L.doorstuck = 1
 			L.visible_message("<span class'danger'>[L] gets stuck in the doorway!</span>")
@@ -35,13 +39,13 @@
 			to_chat(L, "<span class='danger'>With great effort, you manage to squeeze your massive form through  \the [src]. It's a tight fit, but you successfully navigate the narrow opening, barely avoiding getting stuck.</span>")
 			return ..()
 
-	else if(L.fatness > 1890  && L.client?.prefs?.stuckage)
+	else if(L.fatness > (stuckage_weight / 2))
 		if(rand(1, 5) == 1)
 			L.visible_message("<span class'danger'>[L]'s hips brush against the doorway...</span>")
 			to_chat(L, "<span class='danger'>As you pass through  \the [src], you feel a slight brushing against your hips. The [src] frame accommodates your form, but it's a close fit..</span>")
 			return ..()
-	else
-		return ..()
+
+	return ..()
 
 /obj/machinery/door/airlock/abandoned
 	abandoned = TRUE

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -113,34 +113,40 @@
 
 	add_fingerprint(user)
 	. = buckle_mob(M, check_loc = check_loc)
-	if(.)
-		if (M == user && M.fatness >= 3440 && istype(src, /obj/structure/chair)) //GS13 stuff - chair breaking mechanics
-			M.visible_message(\
-				"<span class='notice'>[M] slowly buckles [M.p_them()]self to [src]. their movements slow and deliberate. As [M] settles into the seat, a sudden, violent crash echoes through the air. [M]'s massive weight mercilessly crushes the poor [src], reducing it to pieces! </span>",\
-				"<span class='notice'>You slowly try to buckle yourself to [src]. But it breaks under your massive ass!</span>",\
-				"<span class='italics'>You hear metal clanking.</span>")
-			playsound(loc, 'sound/effects/snap.ogg', 50, 1)
-			playsound(loc, 'sound/effects/woodhit.ogg', 50, 1)
-			playsound(loc, 'sound/effects/bodyfall4.ogg', 50, 1)
-			            // Destroy the src object
-			src.Destroy()
-		else if(M == user && M.fatness >= 1840)
-			M.visible_message(\
-				"<span class='notice'>[M] buckles [M.p_them()]self to the creaking [src]. The [src] protests audibly under the weight as [M]'s ample form settles onto its surface. .</span>",\
-				"<span class='notice'>You buckle yourself to [src].The [src] is cracking and is barely able to hold your weight </span>",\
-				"<span class='italics'>You hear metal clanking.</span>")
-			playsound(loc, 'sound/effects/crossed.ogg', 50, 1)
-		else if(M == user && M.fatness >= 840)
-			M.visible_message(\
-				"<span class='notice'>[M] buckles [M.p_them()]self to the creaking [src] as their weight spreads all over it.</span>",\
-				"<span class='notice'>You buckle yourself to [src].The [src] is creaking as you shuffle a bit </span>",\
-				"<span class='italics'>You hear metal clanking.</span>")
-			playsound(loc, 'sound/effects/crossed.ogg', 50, 1)
-		else
-			M.visible_message(\
-				"<span class='warning'>[user] buckles [M] to [src]!</span>",\
-				"<span class='warning'>[user] buckles you to [src]!</span>",\
-				"<span class='italics'>You hear metal clanking.</span>")
+	if(!.)
+		return
+
+	var/breaking_weight = M?.client?.prefs?.chair_breakage
+	if(!breaking_weight || (M != user) || ((breaking_weight / 3) > M.fatness))
+		M.visible_message(\
+			"<span class='warning'>[user] buckles [M] to [src]!</span>",\
+			"<span class='warning'>[user] buckles you to [src]!</span>",\
+			"<span class='italics'>You hear metal clanking.</span>")
+		return
+
+	if ((M.fatness >= breaking_weight) && istype(src, /obj/structure/chair)) //GS13 stuff - chair breaking mechanics
+		M.visible_message(\
+			"<span class='notice'>[M] slowly buckles [M.p_them()]self to [src]. their movements slow and deliberate. As [M] settles into the seat, a sudden, violent crash echoes through the air. [M]'s massive weight mercilessly crushes the poor [src], reducing it to pieces! </span>",\
+			"<span class='notice'>You slowly try to buckle yourself to [src]. But it breaks under your massive ass!</span>",\
+			"<span class='italics'>You hear metal clanking.</span>")
+		playsound(loc, 'sound/effects/snap.ogg', 50, 1)
+		playsound(loc, 'sound/effects/woodhit.ogg', 50, 1)
+		playsound(loc, 'sound/effects/bodyfall4.ogg', 50, 1)
+					// Destroy the src object
+		src.Destroy()
+	else if(M.fatness >= (breaking_weight / 2))
+		M.visible_message(\
+			"<span class='notice'>[M] buckles [M.p_them()]self to the creaking [src]. The [src] protests audibly under the weight as [M]'s ample form settles onto its surface. .</span>",\
+			"<span class='notice'>You buckle yourself to [src].The [src] is cracking and is barely able to hold your weight </span>",\
+			"<span class='italics'>You hear metal clanking.</span>")
+		playsound(loc, 'sound/effects/crossed.ogg', 50, 1)
+	else if(M.fatness >= (breaking_weight / 3))
+		M.visible_message(\
+			"<span class='notice'>[M] buckles [M.p_them()]self to the creaking [src] as their weight spreads all over it.</span>",\
+			"<span class='notice'>You buckle yourself to [src].The [src] is creaking as you shuffle a bit </span>",\
+			"<span class='italics'>You hear metal clanking.</span>")
+		playsound(loc, 'sound/effects/crossed.ogg', 50, 1)
+
 
 /atom/movable/proc/user_unbuckle_mob(mob/living/buckled_mob, mob/user)
 	var/mob/living/M = unbuckle_mob(buckled_mob)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1069,7 +1069,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Blueberry Inflation:</b><a href='?_src_=prefs;preference=blueberry_inflation'>[blueberry_inflation == TRUE ? "Enabled" : "Disabled"]</a><BR>"
 
 			dat += "<h2>GS13 Gameplay Preferences</h2>"
-			dat += "<b>Stuckage (weight results in getting stuck in doors):</b><a href='?_src_=prefs;preference=stuckage'>[stuckage == TRUE ? "Enabled" : "Disabled"]</a><BR>"
+			dat += "<b>Stuckage (at what weight will you get stuck in doors?):</b><a href='?_src_=prefs;preference=stuckage'>[stuckage == FALSE ? "Disabled" : stuckage]</a><BR>"
+			dat += "<b>Chair Breakage (at what weight will you break chairs?):</b><a href='?_src_=prefs;preference=chair_breakage'>[chair_breakage == FALSE ? "Disabled" : chair_breakage]</a><BR>"
 			dat += "<b>Extreme Weight Gain (Sprite Size scales with weight):</b><a href='?_src_=prefs;preference=weight_gain_extreme'>[weight_gain_extreme == TRUE ? "Enabled" : "Disabled"]</a><BR>"
 
 			dat += "<h2>GS13 Helplessness Preferences</h2>"
@@ -2665,7 +2666,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("bot_feeding")
 					bot_feeding = !bot_feeding
 				if("stuckage")
-					stuckage = !stuckage
+					stuckage = chose_weight("Choose the level of fatness where your weight will hinder your ability to go through airlocks? None will disable this alltogether", user)
+				if("chair_breakage")
+					chair_breakage = chose_weight("Choose the level of fatness where your weight will be too much for chairs to handle? None will disable this alltogether", user)
+
 				if("blueberry_inflation")
 					blueberry_inflation = !blueberry_inflation
 				if("max_fatness")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -171,6 +171,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["helplessness_clothing_back"] >> helplessness_clothing_back
 	S["helplessness_no_buckle"] >> helplessness_no_buckle
 	S["stuckage"] >> stuckage
+	S["chair_breakage"] >> chair_breakage
 	S["blueberry_inflation"] >> blueberry_inflation
 
 
@@ -325,6 +326,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["helplessness_clothing_back"], helplessness_clothing_back)
 	WRITE_FILE(S["helplessness_no_buckle"], helplessness_no_buckle)
 	WRITE_FILE(S["stuckage"], stuckage)
+	WRITE_FILE(S["chair_breakage"], chair_breakage)
 	WRITE_FILE(S["blueberry_inflation"], blueberry_inflation)
 	return 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does as the title says.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
more control good :3
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Chairs breaking under weight and getting stuck in doors are now controlled by prefs, functioning similarly to helplessness now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
