### PR TITLE
Mobility implant

### DIFF
--- a/GainStation13/code/mechanics/den abductors/purchaseble_goodies.dm
+++ b/GainStation13/code/mechanics/den abductors/purchaseble_goodies.dm
@@ -23,6 +23,11 @@
 	credit_cost = 150
 	item_to_dispense = /obj/item/autosurgeon/nutripump_turbo
 
+/datum/feeders_den_goodie/nutripump_turbo
+	name = "Mobility Nanite Core Autosurgeon"
+	credit_cost = 400
+	item_to_dispense = /obj/item/autosurgeon/fat_mobility
+
 /datum/feeders_den_goodie/fatbeam_gun
 	name = "Fatbeam gun"
 	credit_cost = 400

--- a/GainStation13/code/modules/research/designs/nutri_designs.dm
+++ b/GainStation13/code/modules/research/designs/nutri_designs.dm
@@ -68,6 +68,17 @@
 	category = list("Misc", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/cyberimp_fat_mobility
+	name = "Mobility Nanite Core"
+	desc = "This implant contains nanites that reinforce leg muscles, allowing for unimpeded movement at extreme weights."
+	id = "ci-fatmobility"
+	build_type = PROTOLATHE | MECHFAB
+	construction_time = 100
+	materials = list(MAT_METAL = 800, MAT_GLASS = 800, MAT_GOLD = 750, MAT_URANIUM = 1000)
+	build_path = /obj/item/organ/cyberimp/chest/mobility
+	category = list("Misc", "Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+
 /datum/design/bluespace_belt
 	name = "Bluespace Belt"
 	desc = "A belt made using bluespace technology. The power of space and time, used to hide the fact you are fat."

--- a/GainStation13/code/modules/research/techweb/nutritech_nodes.dm
+++ b/GainStation13/code/modules/research/techweb/nutritech_nodes.dm
@@ -5,7 +5,7 @@
 	display_name = "Nutri-Tech Tools"
 	description = "Ending world hunger was never made easier!"
 	prereq_ids = list("biotech", "adv_engi")
-	design_ids = list("calorite_collar", "ci-nutrimentturbo", "bluespace_belt", "adipoelectric_transformer", "cookie_synthesizer", "borg_upgrade_cookiesynthesizer", "borg_upgrade_feedingtube")
+	design_ids = list("calorite_collar", "ci-nutrimentturbo", "bluespace_belt", "adipoelectric_transformer", "cookie_synthesizer", "borg_upgrade_cookiesynthesizer", "borg_upgrade_feedingtube", "ci-fatmobility")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	boost_item_paths = list(/obj/item/gun/energy/fatoray, /obj/item/gun/energy/fatoray/cannon, /obj/item/trash/fatoray_scrap1, /obj/item/trash/fatoray_scrap2)
 	export_price = 5000

--- a/GainStation13/code/modules/surgery/organs/augments.dm
+++ b/GainStation13/code/modules/surgery/organs/augments.dm
@@ -9,3 +9,17 @@
 	hunger_threshold = NUTRITION_LEVEL_FULL
 	poison_amount = 10
 	message = "" //no message cuz spam is annoying
+
+/obj/item/organ/cyberimp/chest/mobility
+	name = "Mobility Nanite Core"
+	desc = "This implant contains nanites that reinforce leg muscles, allowing for unimpeded movement at extreme weights."
+	icon_state = "chest_implant"
+	implant_color = "#9034db"
+
+/obj/item/organ/cyberimp/chest/mobility/Insert(mob/living/carbon/M, special = 0)
+	..()
+	ADD_TRAIT(M, TRAIT_NO_FAT_SLOWDOWN, src)
+
+/obj/item/organ/cyberimp/chest/mobility/Remove(mob/living/carbon/M, special = 0)
+	REMOVE_TRAIT(M, TRAIT_NO_FAT_SLOWDOWN, src)
+	..()

--- a/GainStation13/code/obj/items/minor_items.dm
+++ b/GainStation13/code/obj/items/minor_items.dm
@@ -67,6 +67,11 @@
 	uses = 1
 	starting_organ = /obj/item/organ/cyberimp/chest/nutriment/turbo
 
+/obj/item/autosurgeon/fat_mobility
+	desc = "A single use autosurgeon that contains a mobility nanite core. A screwdriver can be used to remove it, but implants can't be placed back in."
+	uses = 1
+	starting_organ = /obj/item/organ/cyberimp/chest/mobility
+
 //fast food restaurant - closed / open signs
 /obj/item/holosign_creator/restaurant
 	name = "Holosign Projector - Restaurant Adverts"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -230,6 +230,7 @@
 #define TRAIT_NO_BUCKLE "no_buckle"
 #define TRAIT_DOCILE "docile"
 #define TRAIT_LIVESTOCK "livestock"
+#define TRAIT_NO_FAT_SLOWDOWN "no_fat_slowdown"
 
 // common trait sources
 #define TRAIT_GENERIC "generic"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1893,7 +1893,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 		// Hyperstation 13: Mood now influences action speed.
 
-		if(H.fatness) // GS13
+		if(H.fatness && !HAS_TRAIT(H, TRAIT_NO_FAT_SLOWDOWN)) // GS13
 			var/fatness_delay = (H.fatness / FATNESS_DIVISOR)
 			if(H.fatness < FATNESS_LEVEL_BARELYMOBILE)
 				fatness_delay = fatness_delay - flight


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds in the Mobility Nanite Core, an implant that negates all slowdown from being at high weights
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: adds in the Mobility Nanite Core, an implant available through the feedder's den and R&D that negates the move-speed penalty from being a higher weights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
