### PR TITLE
Fixes Lavaland Stew not actually being soup.

### DIFF
--- a/GainStation13/code/modules/food_and_drinks/food.dm
+++ b/GainStation13/code/modules/food_and_drinks/food.dm
@@ -137,13 +137,3 @@
 	tastes = list("eggs", "breakfast" = 1)
 	foodtype = GRAIN | SUGAR
 
-
-
-//GS Food
-
-/obj/item/reagent_containers/food/tribal/soup
-	name = "lavaland stew"
-	desc = "A mixture of various lavaland mushrooms, turned into a bland but medicinal stew."
-	icon = 'icons/obj/food/ported_meals.dmi'
-	icon_state = "lavalandsoup"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/vitfro = 15) //Primarily here to let ashwalkers make medicine. Low nutrient content, high medicine content.

--- a/GainStation13/code/modules/food_and_drinks/recipes/recipes_ported.dm
+++ b/GainStation13/code/modules/food_and_drinks/recipes/recipes_ported.dm
@@ -114,7 +114,7 @@
 
 //GS Food
 
-/datum/crafting_recipe/food/lavaland_soup
+/datum/crafting_recipe/food/lavaland_stew
 	name = "Lavaland Stew"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_leaf = 1,
@@ -122,5 +122,5 @@
 		/obj/item/reagent_containers/food/snacks/grown/ash_flora/cactus_fruit = 2,
 		/obj/item/reagent_containers/glass/bowl/mushroom_bowl = 1
 	)
-	result = /obj/item/reagent_containers/food/tribal/soup
-	subcategory = CAT_PRIMAL
+	result = /obj/item/reagent_containers/food/snacks/soup/lavaland_stew
+	subcategory = CAT_SOUP

--- a/code/modules/food_and_drinks/food/snacks_soup.dm
+++ b/code/modules/food_and_drinks/food/snacks_soup.dm
@@ -271,3 +271,14 @@
 							 /datum/reagent/carbon, /datum/reagent/drug/mushroomhallucinogen)
 	bonus_reagents = list(snowflake_reagent = 5, /datum/reagent/consumable/nutriment = 6)
 	reagents.add_reagent(snowflake_reagent, 5)
+
+
+/obj/item/reagent_containers/food/snacks/soup/lavaland_stew
+	name = "lavaland stew"
+	desc = "A mixture of various lavaland mushrooms, turned into a bland but medicinal stew."
+	icon = 'icons/obj/food/ported_meals.dmi'
+	icon_state = "lavalandsoup"
+	trash = /obj/item/reagent_containers/glass/bowl/mushroom_bowl
+	list_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/vitfro = 15) //Primarily here to let ashwalkers make medicine. Low nutrient content, high medicine content.
+	tastes = list("fresh pickings","extreme blandness" = 1)
+	foodtype = MEAT 


### PR DESCRIPTION
stupid idiot soup item isn't food :(

This fixes it, and also makes you able to recycle the mushroom bowl from it after it's eaten.