### PR TITLE
Permafat changes, Fatfang changes, Bees banned reagents

### DIFF
--- a/GainStation13/code/datums/mutations/fatfang.dm
+++ b/GainStation13/code/datums/mutations/fatfang.dm
@@ -9,6 +9,9 @@
 	instability = 10
 	energy_coeff = 1
 	power_coeff = 1
+	///Which chem is added (lipo default) and how much?
+	var/chem_to_add = /datum/reagent/consumable/lipoifier
+	var/chem_amount = 5
 
 /obj/effect/proc_holder/spell/targeted/touch/fatfang
 	name = "The Nibble"
@@ -27,16 +30,14 @@
 	catchphrase = null
 	icon = 'icons/mob/actions/bloodsucker.dmi'
 	icon_state = "power_feed"
-	///How much weight is added?
-	var/chem_to_add = 5
 	
 	var/starttime = 0
 
 /obj/item/melee/touch_attack/fatfang/afterattack(atom/target, mob/living/carbon/user, proximity)
-	if(!proximity || !iscarbon(target) || target == user)
+	if(!proximity || !iscarbon(target))
 		return FALSE
 	
-	if(!target || !chem_to_add)
+	if(!target || !user.dna.get_mutation(FATFANG).chem_to_add || !user.dna.get_mutation(FATFANG).chem_amount)
 		return FALSE
 	target.visible_message("<span class='danger'>[user] nibbles [target]!</span>","<span class='userdanger'>[user] nibbles you!</span>")
 	if(target == user.pulling && ishuman(user.pulling))
@@ -44,13 +45,12 @@
 		user.dna.get_mutation(FATFANG).power.charge_max = 600 * GET_MUTATION_ENERGY(user.dna.get_mutation(FATFANG))
 		while(starttime + 300 > world.time && in_range(user, target))
 			if(do_mob(user, target, 10, 0, 1))
-				target.reagents.add_reagent(/datum/reagent/consumable/lipoifier, (chem_to_add * GET_MUTATION_POWER(user.dna.get_mutation(FATFANG))/2))
+				target.reagents.add_reagent(user.dna.get_mutation(FATFANG).chem_to_add, (user.dna.get_mutation(FATFANG).chem_amount * GET_MUTATION_POWER(user.dna.get_mutation(FATFANG))/2))
 				target.visible_message("<span class='danger'>[user] pumps some venom in [target]!</span>","<span class='userdanger'>[user] pumps some venom in you!</span>")
 	else
 		user.dna.get_mutation(FATFANG).power.charge_max = 50 * GET_MUTATION_ENERGY(user.dna.get_mutation(FATFANG))
-		target.reagents.add_reagent(/datum/reagent/consumable/lipoifier, chem_to_add * GET_MUTATION_POWER(user.dna.get_mutation(FATFANG)))
-
-	return ..()
+		target.reagents.add_reagent(user.dna.get_mutation(FATFANG).chem_to_add, user.dna.get_mutation(FATFANG).chem_amount * GET_MUTATION_POWER(user.dna.get_mutation(FATFANG)))
+	user.changeNext_move(50)
 
 /obj/item/dnainjector/antifang
 	name = "\improper DNA injector (Anti-The Nibble)"

--- a/GainStation13/code/mechanics/fatness.dm
+++ b/GainStation13/code/mechanics/fatness.dm
@@ -11,8 +11,6 @@ GLOBAL_LIST_INIT(uncapped_resize_areas, list(/area/bridge, /area/crew_quarters, 
 	var/fat_hiders = list()
 	//The actual value a mob is at. Is equal to fatness if fat_hider is FALSE.
 	var/fatness_real = 0
-	//Permanent fatness, which sticks around between rounds
-	var/fatness_perma = 0
 	///At what rate does the parent mob gain weight? 1 = 100%
 	var/weight_gain_rate = 1
 	//At what rate does the parent mob lose weight? 1 = 100%
@@ -51,11 +49,9 @@ GLOBAL_LIST_INIT(uncapped_resize_areas, list(/area/bridge, /area/crew_quarters, 
 	fatness = fatness_real //Make their current fatness their real fatness
 
 	hiders_apply()	//Check and apply hiders
-	perma_apply()	//Check and apply for permanent fat
 	xwg_resize()	//Apply XWG
 
 	return TRUE
-
 
 /mob/living/carbon/fully_heal(admin_revive)
 	fatness = 0
@@ -142,42 +138,10 @@ GLOBAL_LIST_INIT(uncapped_resize_areas, list(/area/bridge, /area/crew_quarters, 
 		if(client?.prefs?.max_weight) //Check their prefs
 			fatness = min(fatness, (client?.prefs?.max_weight - 1)) //And make sure it's not above their preferred max
 
-/mob/living/carbon/proc/perma_apply()
-	if(fatness_perma > 0)	//Check if we need to make calcs at all
-		fatness = fatness + fatness_perma	//Add permanent fat to fatness
-		if(client?.prefs?.max_weight)	//Check for max weight prefs
-			fatness = min(fatness, (client?.prefs?.max_weight - 1))	//Apply max weight prefs
-
-/mob/living/carbon/proc/adjust_perma(adjustment_amount, type_of_fattening = FATTENING_TYPE_ITEM)
-	if(!client)
-		return FALSE
-	if(!client.prefs.weight_gain_permanent)
-		return FALSE
-	
-	if(!adjustment_amount || !type_of_fattening)
-		return FALSE
-
-	if(!HAS_TRAIT(src, TRAIT_UNIVERSAL_GAINER) && client?.prefs)
-		if(!check_weight_prefs(type_of_fattening))
-			return FALSE
-	var/amount_to_change = adjustment_amount
-
-	if(adjustment_amount > 0)
-		amount_to_change = amount_to_change * weight_gain_rate	
-	else
-		amount_to_change = amount_to_change * weight_loss_rate
-
-	fatness_perma += amount_to_change
-	fatness_perma = max(fatness_perma, MINIMUM_FATNESS_LEVEL)
-		
-	if(client?.prefs?.max_weight) // GS13
-		fatness_perma = min(fatness_perma, (client?.prefs?.max_weight - 1))
-
 /mob/living/carbon/human/handle_breathing(times_fired)
 	. = ..()
 	fatness = fatness_real
 	hiders_apply()
-	perma_apply()
 	xwg_resize()
 
 /mob/living/carbon/proc/xwg_resize()

--- a/GainStation13/code/mechanics/fatness.dm
+++ b/GainStation13/code/mechanics/fatness.dm
@@ -11,6 +11,8 @@ GLOBAL_LIST_INIT(uncapped_resize_areas, list(/area/bridge, /area/crew_quarters, 
 	var/fat_hiders = list()
 	//The actual value a mob is at. Is equal to fatness if fat_hider is FALSE.
 	var/fatness_real = 0
+	//Permanent fatness, which sticks around between rounds
+	var/fatness_perma = 0
 	///At what rate does the parent mob gain weight? 1 = 100%
 	var/weight_gain_rate = 1
 	//At what rate does the parent mob lose weight? 1 = 100%
@@ -49,6 +51,7 @@ GLOBAL_LIST_INIT(uncapped_resize_areas, list(/area/bridge, /area/crew_quarters, 
 	fatness = fatness_real //Make their current fatness their real fatness
 
 	hiders_apply()	//Check and apply hiders
+	perma_apply()	//Check and apply for permanent fat
 	xwg_resize()	//Apply XWG
 
 	return TRUE
@@ -138,10 +141,42 @@ GLOBAL_LIST_INIT(uncapped_resize_areas, list(/area/bridge, /area/crew_quarters, 
 		if(client?.prefs?.max_weight) //Check their prefs
 			fatness = min(fatness, (client?.prefs?.max_weight - 1)) //And make sure it's not above their preferred max
 
+/mob/living/carbon/proc/perma_apply()
+	if(fatness_perma > 0)	//Check if we need to make calcs at all
+		fatness = fatness + fatness_perma	//Add permanent fat to fatness
+		if(client?.prefs?.max_weight)	//Check for max weight prefs
+			fatness = min(fatness, (client?.prefs?.max_weight - 1))	//Apply max weight prefs
+
+/mob/living/carbon/proc/adjust_perma(adjustment_amount, type_of_fattening = FATTENING_TYPE_ITEM)
+	if(!client)
+		return FALSE
+	if(!client.prefs.weight_gain_permanent)
+		return FALSE
+	
+	if(!adjustment_amount || !type_of_fattening)
+		return FALSE
+
+	if(!HAS_TRAIT(src, TRAIT_UNIVERSAL_GAINER) && client?.prefs)
+		if(!check_weight_prefs(type_of_fattening))
+			return FALSE
+	var/amount_to_change = adjustment_amount
+
+	if(adjustment_amount > 0)
+		amount_to_change = amount_to_change * weight_gain_rate	
+	else
+		amount_to_change = amount_to_change * weight_loss_rate
+
+	fatness_perma += amount_to_change
+	fatness_perma = max(fatness_perma, MINIMUM_FATNESS_LEVEL)
+		
+	if(client?.prefs?.max_weight) // GS13
+		fatness_perma = min(fatness_perma, (client?.prefs?.max_weight - 1))
+
 /mob/living/carbon/human/handle_breathing(times_fired)
 	. = ..()
 	fatness = fatness_real
 	hiders_apply()
+	perma_apply()
 	xwg_resize()
 
 /mob/living/carbon/proc/xwg_resize()

--- a/GainStation13/code/mechanics/permanent_fat.dm
+++ b/GainStation13/code/mechanics/permanent_fat.dm
@@ -1,6 +1,8 @@
 /datum/preferences/proc/perma_fat_save(character)
 	if(iscarbon(character))
 		var/mob/living/carbon/C = character
+		if(!C.client.prefs.weight_gain_permanent)
+			return FALSE
 		if(!path)
 			return 0
 			if(world.time < savecharcooldown)
@@ -15,4 +17,4 @@
 			return 0
 		S.cd = "/character[default_slot]"
 		
-		WRITE_FILE(S["permanent_fat"]			, C.fatness_perma)
+		WRITE_FILE(S["starting_weight"]			, C.fatness_real)

--- a/GainStation13/code/mechanics/permanent_fat.dm
+++ b/GainStation13/code/mechanics/permanent_fat.dm
@@ -1,7 +1,36 @@
+/mob/living/carbon
+	var/savekey
+	var/ckeyslot
+
+/mob/living/carbon/proc/perma_fat_save(mob/living/carbon/character)
+	var/key = savekey
+	if(!key)
+		return FALSE 
+	var/filename = "preferences.sav"
+	var/path = "data/player_saves/[key[1]]/[key]/[filename]"
+
+	var/savefile/S = new /savefile(path)
+	if(!path)
+		return FALSE
+
+	if(character.ckeyslot)
+		var/slot = character.ckeyslot
+		S.cd = "/character[slot]"
+
+		var/persi
+		S["weight_gain_persistent"] >> persi
+		if(persi)
+			WRITE_FILE(S["starting_weight"]			, character.fatness_real)
+		var/perma 
+		S["weight_gain_permanent"] >> perma
+		if(S["weight_gain_permanent"])
+			WRITE_FILE(S["permanent_fat"]			, character.fatness_perma)
+
+/*
 /datum/preferences/proc/perma_fat_save(character)
 	if(iscarbon(character))
 		var/mob/living/carbon/C = character
-		if(!C.client.prefs.weight_gain_permanent)
+		if(!C.client.prefs.weight_gain_permanent && !C.client.prefs.weight_gain_persistent)
 			return FALSE
 		if(!path)
 			return 0
@@ -17,4 +46,8 @@
 			return 0
 		S.cd = "/character[default_slot]"
 		
-		WRITE_FILE(S["starting_weight"]			, C.fatness_real)
+		if(C.client.prefs.weight_gain_persistent)
+			WRITE_FILE(S["starting_weight"]			, C.fatness_real)
+		if(C.client.prefs.weight_gain_permanent)
+			WRITE_FILE(S["permanent_fat"]			, C.fatness_perma)
+*/

--- a/GainStation13/code/modules/client/preferences/preferences.dm
+++ b/GainStation13/code/modules/client/preferences/preferences.dm
@@ -19,6 +19,8 @@
 	var/blueberry_inflation = FALSE
 	///Extreme weight gain
 	var/weight_gain_extreme = FALSE
+	///Persistant fatness
+	var/weight_gain_persistent = FALSE
 	///Permanent weight gain
 	var/weight_gain_permanent = FALSE
 	/// At what weight will you start to get stuck in airlocks?

--- a/GainStation13/code/modules/reagents/chemistry/reagents/fermi_fat.dm
+++ b/GainStation13/code/modules/reagents/chemistry/reagents/fermi_fat.dm
@@ -1,5 +1,3 @@
-///datum/reagent/sizechem
-
 //Reagent
 /datum/reagent/fermi_fat
 	name = "Galbanic Compound"
@@ -55,7 +53,6 @@
 	if(!iscarbon(M))
 		return..()
 	M.adjust_fatness(30, FATTENING_TYPE_CHEM)
-	M.adjust_perma(1, FATTENING_TYPE_CHEM)
 	..()
 	. = 1
 
@@ -65,7 +62,6 @@
 		return..()
 	var/mob/living/carbon/C = M
 	C.adjust_fatness(20, FATTENING_TYPE_CHEM)
-	C.adjust_perma(1, FATTENING_TYPE_CHEM)
 	..()
 
 /datum/reagent/fermi_fat/overdose_start(mob/living/M)
@@ -83,7 +79,7 @@
 		C.adjust_fatness(1, FATTENING_TYPE_CHEM)
 		C.fullness = max(0, C.fullness-1)
 		C.nutrition = max(0, C.nutrition-1)
-		if(addiction_mults == 0)
+		if(addiction_mults < 1)
 			C.nutri_mult += 0.5
 			C.weight_gain_rate += 0.25
 			addiction_mults = 1
@@ -99,7 +95,7 @@
 		C.adjust_fatness(2, FATTENING_TYPE_CHEM)
 		C.fullness = max(0, C.fullness-2)
 		C.nutrition = max(0, C.nutrition-2)
-		if(addiction_mults <= 1)
+		if(addiction_mults < 2)
 			C.nutri_mult += 0.5
 			C.weight_gain_rate += 0.25
 			addiction_mults = 2
@@ -115,7 +111,7 @@
 		C.adjust_fatness(3, FATTENING_TYPE_CHEM)
 		C.fullness = max(0, C.fullness-3)
 		C.nutrition = max(0, C.nutrition-3)
-		if(addiction_mults <= 2)
+		if(addiction_mults < 3)
 			C.nutri_mult += 0.5
 			C.weight_gain_rate += 0.25
 			addiction_mults = 3
@@ -131,7 +127,7 @@
 		C.adjust_fatness(4, FATTENING_TYPE_CHEM)
 		C.fullness = max(0, C.fullness-4)
 		C.nutrition = max(0, C.nutrition-4)
-		if(addiction_mults <= 3)
+		if(addiction_mults < 4)
 			C.nutri_mult += 0.5
 			C.weight_gain_rate += 0.25
 			addiction_mults = 4
@@ -143,6 +139,7 @@
 		C.weight_gain_rate = max(0,11, 0.25 * addiction_mults)
 	return
 
+//Reagent
 /datum/reagent/fermi_slim
 	name = "Macerinic Solution"
 	description = "A solution with unparalleled obesity-solving properties. One of the few things known to be capable of removing galbanic fat."
@@ -151,6 +148,8 @@
 	pH = 7
 	metabolization_rate = REAGENTS_METABOLISM / 4
 	can_synth = FALSE
+
+	overdose_threshold = 50
 
 //Reaction
 /datum/chemical_reaction/fermi_slim
@@ -181,6 +180,14 @@
 	if(!iscarbon(M))
 		return..()
 	M.adjust_fatness(-50, FATTENING_TYPE_CHEM)
-	M.adjust_perma(-5, FATTENING_TYPE_CHEM)
 	..()
 	. = 1
+
+/datum/reagent/fermi_slim/overdose_process(mob/living/M)
+	if(!iscarbon(M))
+		return..()
+	var/mob/living/carbon/C = M
+	C.fullness = max(0, C.fullness-5)
+	C.nutrition = max(0, C.nutrition-5)
+	C.weight_loss_rate = min(5, C.weight_loss_rate+0.01)
+	..()

--- a/GainStation13/code/modules/reagents/chemistry/reagents/fermi_fat.dm
+++ b/GainStation13/code/modules/reagents/chemistry/reagents/fermi_fat.dm
@@ -53,6 +53,7 @@
 	if(!iscarbon(M))
 		return..()
 	M.adjust_fatness(30, FATTENING_TYPE_CHEM)
+	M.adjust_perma(1, FATTENING_TYPE_CHEM)
 	..()
 	. = 1
 
@@ -62,6 +63,7 @@
 		return..()
 	var/mob/living/carbon/C = M
 	C.adjust_fatness(20, FATTENING_TYPE_CHEM)
+	C.adjust_perma(1, FATTENING_TYPE_CHEM)
 	..()
 
 /datum/reagent/fermi_fat/overdose_start(mob/living/M)
@@ -179,7 +181,8 @@
 /datum/reagent/fermi_slim/on_mob_life(mob/living/carbon/M)
 	if(!iscarbon(M))
 		return..()
-	M.adjust_fatness(-50, FATTENING_TYPE_CHEM)
+	M.adjust_fatness(-50, FATTENING_TYPE_WEIGHT_LOSS)
+	M.adjust_perma(-5, FATTENING_TYPE_WEIGHT_LOSS)
 	..()
 	. = 1
 

--- a/code/__DEFINES/pool.dm
+++ b/code/__DEFINES/pool.dm
@@ -9,5 +9,6 @@ GLOBAL_LIST_INIT(blacklisted_pool_reagents, list(
 	/datum/reagent/toxin/plasma, /datum/reagent/oxygen, /datum/reagent/nitrous_oxide, /datum/reagent/nitrogen,		//gases
 	/datum/reagent/fermi,		//blanket fermichem ban sorry. this also covers mkultra, genital enlargers, etc etc.
 	/datum/reagent/drug/aphrodisiac, /datum/reagent/drug/anaphrodisiac, /datum/reagent/drug/aphrodisiacplus, /datum/reagent/drug/anaphrodisiacplus,		//literally asking for prefbreaks
-	/datum/reagent/consumable/femcum, /datum/reagent/consumable/semen			//NO.
+	/datum/reagent/consumable/femcum, /datum/reagent/consumable/semen,			//NO.
+	/datum/reagent/fermi_fat, /datum/reagent/fermi_slim		//GS13 fermi fat chems
 	))

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -6,10 +6,11 @@
 
 	//GS13 Process permanent fat
 	for(var/mob/m in GLOB.player_list)
-		if(m.client.prefs)
-			if(m.client.ckey)
-				m.client.prefs.perma_fat_save(m)
-	
+		if(iscarbon(m))
+			var/mob/living/carbon/C = m
+			if(C)
+				C.perma_fat_save(C)
+		
 	gather_antag_data()
 	record_nuke_disk_location()
 	var/json_file = file("[GLOB.log_directory]/round_end_data.json")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -105,7 +105,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	//GS13
 	var/starting_weight = 0				//how thicc you wanna be at start
-	var/permanent_fat = 0				//If it isn't the consequences of your own actions
 	var/wg_rate = 0.5
 	var/wl_rate = 0.5
 	var/voice = "human"
@@ -1077,7 +1076,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "This preference functions similar to the one before but allows for items with more drastic effects. <b>Do not enable this if you aren't okay with more drastic things happening to your character.</b><BR>"
 			dat += "<b>Extreme Fatness Vulnerability:</b><a href='?_src_=prefs;preference=extreme_fatness_vulnerable'>[extreme_fatness_vulnerable == TRUE ? "Enabled" : "Disabled"]</a><BR>"
 			dat += "<b>Extreme Weight Gain (Sprite Size scales with weight):</b><a href='?_src_=prefs;preference=weight_gain_extreme'>[weight_gain_extreme == TRUE ? "Enabled" : "Disabled"]</a><BR>"
-			dat += "<b>Weight Gain Permanent (special weight persists between rounds):</b><a href='?_src_=prefs;preference=weight_gain_permanent'>[weight_gain_permanent == TRUE ? "Enabled" : "Disabled"]</a><BR>"
+			dat += "<b>Weight Gain Permanent (endround/cryo weight becomes your new start weight):</b><a href='?_src_=prefs;preference=weight_gain_permanent'>[weight_gain_permanent == TRUE ? "Enabled" : "Disabled"]</a><BR>"
 
 			dat += "<h2>GS13 Helplessness Preferences</h2>"
 			dat += "<b>Please be careful when using these mechanics as not to use them in a way that negatively impacts those around you. If you are seriously needed for something, especially something station critical, do not use these as an excuse to ignore your duty.</b><BR><BR>"
@@ -3001,7 +3000,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//GS13
 	character.fatness = starting_weight
 	character.fatness_real = starting_weight
-	character.fatness_perma = permanent_fat
 	character.weight_gain_rate = wg_rate
 	character.weight_loss_rate = wl_rate
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -105,9 +105,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	//GS13
 	var/starting_weight = 0				//how thicc you wanna be at start
+	var/permanent_fat = 0				//If it isn't the consequences of your own actions
 	var/wg_rate = 0.5
 	var/wl_rate = 0.5
 	var/voice = "human"
+	var/ckeyslot
 
 	//HS13 jobs
 	var/sillyroles = TRUE //for clown and mime
@@ -1076,7 +1078,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "This preference functions similar to the one before but allows for items with more drastic effects. <b>Do not enable this if you aren't okay with more drastic things happening to your character.</b><BR>"
 			dat += "<b>Extreme Fatness Vulnerability:</b><a href='?_src_=prefs;preference=extreme_fatness_vulnerable'>[extreme_fatness_vulnerable == TRUE ? "Enabled" : "Disabled"]</a><BR>"
 			dat += "<b>Extreme Weight Gain (Sprite Size scales with weight):</b><a href='?_src_=prefs;preference=weight_gain_extreme'>[weight_gain_extreme == TRUE ? "Enabled" : "Disabled"]</a><BR>"
-			dat += "<b>Weight Gain Permanent (endround/cryo weight becomes your new start weight):</b><a href='?_src_=prefs;preference=weight_gain_permanent'>[weight_gain_permanent == TRUE ? "Enabled" : "Disabled"]</a><BR>"
+			dat += "<b>Persistent Fat (endround/cryo weight becomes your new start weight):</b><a href='?_src_=prefs;preference=weight_gain_persistent'>[weight_gain_persistent == TRUE ? "Enabled" : "Disabled"]</a><BR>"
+			dat += "<b>Permanent Weight (hard to remove and persistent weight):</b><a href='?_src_=prefs;preference=weight_gain_permanent'>[weight_gain_permanent == TRUE ? "Enabled" : "Disabled"]</a><BR>"
 
 			dat += "<h2>GS13 Helplessness Preferences</h2>"
 			dat += "<b>Please be careful when using these mechanics as not to use them in a way that negatively impacts those around you. If you are seriously needed for something, especially something station critical, do not use these as an excuse to ignore your duty.</b><BR><BR>"
@@ -2666,6 +2669,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					weight_gain_nanites = !weight_gain_nanites
 				if("weight_gain_extreme")
 					weight_gain_extreme = !weight_gain_extreme
+				if("weight_gain_persistent")
+					weight_gain_persistent = !weight_gain_persistent
 				if("weight_gain_permanent")
 					weight_gain_permanent = !weight_gain_permanent
 				if("noncon_weight_gain")
@@ -3000,8 +3005,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//GS13
 	character.fatness = starting_weight
 	character.fatness_real = starting_weight
+	if(weight_gain_permanent)
+		character.fatness_perma = permanent_fat
 	character.weight_gain_rate = wg_rate
 	character.weight_loss_rate = wl_rate
+	character.savekey = clientckey
+	character.ckeyslot = ckeyslot
 
 	character.gender = gender
 	character.age = age

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -333,7 +333,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["age"]				>> age
 	S["body_size"]			>> body_size
 	S["starting_weight"]	>> starting_weight
-	S["permanent_fat"]		>> permanent_fat
 	S["wg_rate"]			>> wg_rate
 	S["wl_rate"]			>> wl_rate
 	S["hair_color"]			>> hair_color

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -298,6 +298,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		default_slot = slot
 		WRITE_FILE(S["default_slot"] , slot)
 
+	ckeyslot = slot
 	S.cd = "/character[slot]"
 	var/needs_update = savefile_needs_update(S)
 	if(needs_update == -2)		//fatal, can't load any data
@@ -333,6 +334,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["age"]				>> age
 	S["body_size"]			>> body_size
 	S["starting_weight"]	>> starting_weight
+	S["permanent_fat"]		>> permanent_fat
 	S["wg_rate"]			>> wg_rate
 	S["wl_rate"]			>> wl_rate
 	S["hair_color"]			>> hair_color
@@ -494,6 +496,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["weight_gain_nanites"] >> weight_gain_nanites
 	S["weight_gain_weapons"] >> weight_gain_weapons
 	S["weight_gain_extreme"] >> weight_gain_extreme
+	S["weight_gain_persistent"] >> weight_gain_persistent
 	S["weight_gain_permanent"] >> weight_gain_permanent
 	S["wg_rate"] >> wg_rate
 	S["wl_rate"] >> wl_rate
@@ -713,6 +716,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["weight_gain_chems"], weight_gain_chems)
 	WRITE_FILE(S["weight_gain_weapons"], weight_gain_weapons)
 	WRITE_FILE(S["weight_gain_extreme"], weight_gain_extreme)
+	WRITE_FILE(S["weight_gain_persistent"], weight_gain_persistent)
 	WRITE_FILE(S["weight_gain_permanent"], weight_gain_permanent)
 	WRITE_FILE(S["wg_rate"], wg_rate)
 	WRITE_FILE(S["wl_rate"], wl_rate)

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -1,3 +1,4 @@
+GLOBAL_LIST_INIT(bee_banned_chem, list(/datum/reagent/fermi_fat, /datum/reagent/fermi_slim))
 
 #define BEE_IDLE_ROAMING		70 //The value of idle at which a bee in a beebox will try to wander
 #define BEE_IDLE_GOHOME			0  //The value of idle at which a bee will try to go home
@@ -272,13 +273,16 @@
 			queen.paxed = TRUE
 		else
 			var/datum/reagent/R = GLOB.chemical_reagents_list[S.reagents.get_master_reagent_id()]
-			if(R && S.reagents.has_reagent(R.type, 5))
-				S.reagents.remove_reagent(R.type,5)
-				queen.assign_reagent(R)
-				user.visible_message("<span class='warning'>[user] injects [src]'s genome with [R.name], mutating it's DNA!</span>","<span class='warning'>You inject [src]'s genome with [R.name], mutating it's DNA!</span>")
-				name = queen.name
+			if(!is_type_in_list(R, GLOB.bee_banned_chem))
+				if(R && S.reagents.has_reagent(R.type, 5))
+					S.reagents.remove_reagent(R.type,5)
+					queen.assign_reagent(R)
+					user.visible_message("<span class='warning'>[user] injects [src]'s genome with [R.name], mutating it's DNA!</span>","<span class='warning'>You inject [src]'s genome with [R.name], mutating it's DNA!</span>")
+					name = queen.name
+				else
+					to_chat(user, "<span class='warning'>You don't have enough units of that chemical to modify the bee's DNA!</span>")
 			else
-				to_chat(user, "<span class='warning'>You don't have enough units of that chemical to modify the bee's DNA!</span>")
+				to_chat(user, "<span class='warning'>The bee rejects the injection! This chem is incompatible!</span>")
 	..()
 
 

--- a/modular_citadel/code/game/machinery/cryopod.dm
+++ b/modular_citadel/code/game/machinery/cryopod.dm
@@ -249,9 +249,10 @@
 	var/mob/living/mob_occupant = occupant
 
 	//GS13 Process permanent fat
-	if(mob_occupant.client.prefs)
-		if(mob_occupant.client.ckey)
-			mob_occupant.client.prefs.perma_fat_save(mob_occupant)
+	if(iscarbon(mob_occupant))
+		var/mob/living/carbon/C = mob_occupant
+		if(C)
+			C.perma_fat_save(C)
 
 	//Update any existing objectives involving this mob.
 	for(var/datum/objective/O in GLOB.objectives)


### PR DESCRIPTION
Permanent fat renamed to permanent weight
Added persistent fat. If enabled, it will save your character's real fatness at roundend or cryo as your new starting weight. Starting weight can still be tweaked from 0 to 8000 should you want to lose some of it.
Tweaked galbanic compound to behave better while addicted.
Macerinic solution can now be overdosed (50u). Overdosing causes your character to get hungry but also increases your weight loss rate up to 5

The Nibble mutation now allows you to bite yourself. The fangs no longer disappear after use, making drawing them out again needed, but remain in the hand. After an attack with them, you'll go into a 5 seconds melee cooldown. Internal change for admin memery, chem and amount injected can be changed as they are now tied to vars inside the mutation

Added a list of reagents that cannot be injected into queen bees, currently contains Galbanic Compound and Macerinic Solution
Added fermi fat chems to pool reagents blacklist

Bug that caused cryopods to not teleport afk people fixed
Fixed issues regarding saving persistent fat or permanent weight while in another player's character