### PR TITLE
Makes you able to hear farts that arnt being blasted directly into your face

### DIFF
--- a/GainStation13/code/modules/mob/living/emote.dm
+++ b/GainStation13/code/modules/mob/living/emote.dm
@@ -6,17 +6,7 @@
 	sound = 'GainStation13/sound/voice/gurgle1.ogg'
 
 /datum/emote/living/gurgle/get_sound()
-	return pick('GainStation13/sound/voice/gurgle1.ogg',
-				'GainStation13/sound/voice/gurgle2.ogg',
-				'GainStation13/sound/voice/gurgle3.ogg')
-
-/datum/emote/living/gurgle/run_emote(mob/living/user, params)
-	if(!ishuman(user))
-		return FALSE
-
-	playsound(user, "gurgle")
-
-	. = ..()
+	return get_sfx("gurgle") // Lets get any of the gurgle sounds we have set.
 
 /datum/emote/living/burp
 	key = "burp"
@@ -33,7 +23,7 @@
 	if(!.)
 		return FALSE
 	
-	playsound_prefed(user, noise_type, noise_pref, 100, TRUE, -7)
+	playsound_prefed(user, noise_type, noise_pref, 100, TRUE, -4)
 
 	user.reduce_fullness(rand(reduction_min,reduction_max))
 
@@ -69,6 +59,7 @@
 	key_third_person = "belches loudly"
 	message = "belches"
 	//god hates me for this -Metha
+	noise_type = "belch"
 	reduction_min = 6
 	reduction_max = 12
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I accidentally made the radius of prefed sounds from burping, farting and so on only have a radius of 1, meaning you'd have to be on the same tile to hear them. This fixes that. It also fixes belches only pulling burp sound effects.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Give me my TGstation bugfix goodboy points
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed range of burps, farts and other preffed emote sounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
