### PR TITLE
Reworks toolbelts and upgrades engineer and durathread toolbelts

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -22,6 +22,7 @@ RLD
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags = SLOT_BELT
 	materials = list(MAT_METAL=100000)
 	req_access_txt = "11"
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -188,6 +188,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	throw_speed = 1
 	throw_range = 5
 	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags = SLOT_BELT
 	materials = list(MAT_METAL=75000, MAT_GLASS=37500)
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -6,6 +6,7 @@
 	item_state = "utility"
 	lefthand_file = 'icons/mob/inhands/equipment/belt_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/belt_righthand.dmi'
+	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BELT
 	attack_verb = list("whipped", "lashed", "disciplined")
 	max_integrity = 300
@@ -47,7 +48,10 @@
 /obj/item/storage/belt/utility/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	var/static/list/can_hold = typecacheof(list(
+	STR.max_items = 11
+	STR.max_w_class = WEIGHT_CLASS_NORMAL
+	STR.max_combined_w_class = 24
+	STR.can_hold = typecacheof(list(
 		/obj/item/crowbar,
 		/obj/item/screwdriver,
 		/obj/item/weldingtool,
@@ -62,16 +66,24 @@
 		/obj/item/extinguisher/mini,
 		/obj/item/radio,
 		/obj/item/clothing/gloves,
-		/obj/item/holosign_creator,
+		/obj/item/holosign_creator/atmos,
+		/obj/item/holosign_creator/firelock
+		/obj/item/holosign_creator/engineering,
 		/obj/item/forcefield_projector,
 		/obj/item/assembly/signaler,
+		/obj/item/lightreplacer,
+		/obj/item/pipe_dispenser,
+		/obj/item/inducer,
+		/obj/item/grenade/chem_grenade/smart_metal_foam,
+		/obj/item/grenade/chem_grenade/metalfoam,
+		/obj/item/handdrill
+		/obj/item/jawsoflife
 		/obj/item/carpentry/handsaw,
 		/obj/item/carpentry/hammer,
 		/obj/item/carpentry/sandpaper,
 		/obj/item/carpentry/borer,
 		/obj/item/carpentry/glue
 		))
-	STR.can_hold = can_hold
 
 /obj/item/storage/belt/utility/chief
 	name = "\improper Chief Engineer's toolbelt" //"the Chief Engineer's toolbelt", because "Chief Engineer's toolbelt" is not a proper noun
@@ -136,6 +148,7 @@
 /obj/item/storage/belt/medical/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_items = 11
 	STR.max_w_class = WEIGHT_CLASS_BULKY
 	STR.can_hold = typecacheof(list(
 		/obj/item/healthanalyzer,
@@ -474,7 +487,7 @@ obj/item/storage/belt/slut/ComponentInitialize()
 
 /obj/item/storage/belt/durathread
 	name = "durathread toolbelt"
-	desc = "A toolbelt made out of durathread, it seems resistant enough to hold even big tools like an RCD, it also has higher capacity."
+	desc = "A toolbelt made out of durathread, it seems resistant enough to hold an assortment of different tools and it also has higher capacity."
 	icon_state = "webbing-durathread"
 	item_state = "webbing-durathread"
 	resistance_flags = FIRE_PROOF
@@ -482,8 +495,8 @@ obj/item/storage/belt/slut/ComponentInitialize()
 /obj/item/storage/belt/durathread/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 14
-	STR.max_combined_w_class = 32
+	STR.max_items = 20
+	STR.max_combined_w_class = 36
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.can_hold = typecacheof(list(
 		/obj/item/ammo_box,

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -70,31 +70,6 @@
 	force = 10
 	toolspeed = 0.5
 
-/obj/item/crowbar/power
-	name = "jaws of life"
-	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a prying head."
-	icon_state = "jaws_pry"
-	item_state = "jawsoflife"
-	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	materials = list(MAT_METAL=150,MAT_SILVER=50,MAT_TITANIUM=25)
-
-	usesound = 'sound/items/jaws_pry.ogg'
-	force = 15
-	toolspeed = 0.25
-
-/obj/item/crowbar/power/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is putting [user.p_their()] head in [src], it looks like [user.p_theyre()] trying to commit suicide!</span>")
-	playsound(loc, 'sound/items/jaws_pry.ogg', 50, 1, -1)
-	return (BRUTELOSS)
-
-/obj/item/crowbar/power/attack_self(mob/user)
-	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
-	var/obj/item/wirecutters/power/cutjaws = new /obj/item/wirecutters/power(drop_location())
-	to_chat(user, "<span class='notice'>You attach the cutting jaws to [src].</span>")
-	qdel(src)
-	user.put_in_active_hand(cutjaws)
-
 /obj/item/crowbar/advanced
 	name = "advanced crowbar"
 	desc = "A scientist's almost successful reproduction of an abductor's crowbar, it uses the same technology combined with a handle that can't quite hold it."

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -109,36 +109,6 @@
 /obj/item/screwdriver/abductor/get_belt_overlay()
 	return mutable_appearance('icons/obj/clothing/belt_overlays.dmi', "screwdriver_nuke")
 
-/obj/item/screwdriver/power
-	name = "hand drill"
-	desc = "A simple powered hand drill. It's fitted with a screw bit."
-	icon_state = "drill_screw"
-	item_state = "drill"
-	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	materials = list(MAT_METAL=150,MAT_SILVER=50,MAT_TITANIUM=25) //done for balance reasons, making them high value for research, but harder to get
-	force = 8 //might or might not be too high, subject to change
-	w_class = WEIGHT_CLASS_SMALL
-	throwforce = 8
-	throw_speed = 2
-	throw_range = 3//it's heavier than a screw driver/wrench, so it does more damage, but can't be thrown as far
-	attack_verb = list("drilled", "screwed", "jabbed","whacked")
-	hitsound = 'sound/items/drill_hit.ogg'
-	usesound = 'sound/items/drill_use.ogg'
-	toolspeed = 0.25
-	random_color = FALSE
-
-/obj/item/screwdriver/power/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is putting [src] to [user.p_their()] temple. It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	return(BRUTELOSS)
-
-/obj/item/screwdriver/power/attack_self(mob/user)
-	playsound(get_turf(user),'sound/items/change_drill.ogg',50,1)
-	var/obj/item/wrench/power/b_drill = new /obj/item/wrench/power(drop_location())
-	to_chat(user, "<span class='notice'>You attach the bolt driver bit to [src].</span>")
-	qdel(src)
-	user.put_in_active_hand(b_drill)
-
 /obj/item/screwdriver/cyborg
 	name = "powered screwdriver"
 	desc = "An electrical screwdriver, designed to be both precise and quick."

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -121,23 +121,6 @@
 	qdel(src)
 	user.put_in_active_hand(pryjaws)
 
-/obj/item/wirecutters/power/attack(mob/living/carbon/C, mob/user)
-	if(istype(C))
-		if(C.handcuffed)
-			user.visible_message("<span class='notice'>[user] cuts [C]'s restraints with [src]!</span>")
-			qdel(C.handcuffed)
-			return
-		else if(C.has_status_effect(STATUS_EFFECT_CHOKINGSTRAND))
-			var/man = C == user ? "your" : "[C]'\s"
-			user.visible_message("<span class='notice'>[user] attempts to remove the durathread strand from around [man] neck.</span>", \
-								"<span class='notice'>You attempt to remove the durathread strand from around [man] neck.</span>")
-			if(do_after(user, 15, null, C))
-				user.visible_message("<span class='notice'>[user] succesfuly removes the durathread strand.</span>",
-									"<span class='notice'>You succesfuly remove the durathread strand.</span>")
-				C.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
-			return
-	..()
-
 /obj/item/wirecutters/advanced
 	name = "advanced wirecutters"
 	desc = "A set of reproduction alien wirecutters, they have a silver handle with an exceedingly sharp blade."

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -52,33 +52,6 @@
 	usesound = 'sound/effects/empulse.ogg'
 	toolspeed = 0.1
 
-/obj/item/wrench/power
-	name = "hand drill"
-	desc = "A simple powered hand drill. It's fitted with a bolt bit."
-	icon_state = "drill_bolt"
-	item_state = "drill"
-	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	usesound = 'sound/items/drill_use.ogg'
-	materials = list(MAT_METAL=150,MAT_SILVER=50,MAT_TITANIUM=25)
- //done for balance reasons, making them high value for research, but harder to get
-	force = 8 //might or might not be too high, subject to change
-	w_class = WEIGHT_CLASS_SMALL
-	throwforce = 8
-	attack_verb = list("drilled", "screwed", "jabbed")
-	toolspeed = 0.25
-
-/obj/item/wrench/power/attack_self(mob/user)
-	playsound(get_turf(user),'sound/items/change_drill.ogg',50,1)
-	var/obj/item/wirecutters/power/s_drill = new /obj/item/screwdriver/power(drop_location())
-	to_chat(user, "<span class='notice'>You attach the screw driver bit to [src].</span>")
-	qdel(src)
-	user.put_in_active_hand(s_drill)
-
-/obj/item/wrench/power/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is pressing [src] against [user.p_their()] head! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	return (BRUTELOSS)
-
 /obj/item/wrench/medical
 	name = "medical wrench"
 	desc = "A medical wrench with common(medical?) uses. Can be found in your hand."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3500,5 +3500,6 @@
 #include "modular_citadel\interface\skin.dmf"
 #include "v_CHOMPstation2\code\clothing\head.dm"
 #include "v_CHOMPstation2\code\clothing\suits.dm"
+#include "yogstation\code\game\objects\items\tools.dm"
 #include "yogstation\code\modules\power\energyharvester.dm"
 // END_INCLUDE

--- a/yogstation/code/game/objects/items/tools.dm
+++ b/yogstation/code/game/objects/items/tools.dm
@@ -1,0 +1,234 @@
+// Porting this pretty much verbatim from Yogstation Code, but Im pretty sure it's just TG code. I just have a copy of yogs onhand. -Reo
+// Looking again. And it's in yog's modularity folder, and we already have a yogs folder, so im putting it in here.
+//the new and improved jaws
+/obj/item/jawsoflife
+	name = "jaws of life"
+	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a prying head."
+	materials = list(/datum/material/iron=150,/datum/material/silver=50,/datum/material/titanium=25)
+	icon = 'icons/obj/tools.dmi'
+	icon_state = "jaws_pry"
+	item_state = "jawsoflife"
+	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
+	w_class = WEIGHT_CLASS_SMALL
+	usesound = 'sound/items/jaws_pry.ogg'
+	force = 15
+	toolspeed = 0.7
+	tool_behaviour = TOOL_CROWBAR
+	var/pryforce = 1 // the speed at which airlocks are pried open. Default is 1 .
+
+//jaws of life changing jaw code
+/obj/item/jawsoflife/attack_self(mob/user)
+	if (tool_behaviour == TOOL_CROWBAR)
+		transform_cutters(user)
+	else
+		transform_crowbar(user)
+
+//jaws of life suicide code
+/obj/item/jawsoflife/suicide_act(mob/user)
+	switch(tool_behaviour)
+		if(TOOL_CROWBAR)
+			user.visible_message(span_suicide("[user] is putting [user.p_their()] head in [src], it looks like [user.p_theyre()] trying to commit suicide!"))
+			playsound(loc, 'sound/items/jaws_pry.ogg', 50, 1, -1)
+		if(TOOL_WIRECUTTER)
+			user.visible_message(span_suicide("[user] is wrapping \the [src] around [user.p_their()] neck. It looks like [user.p_theyre()] trying to rip [user.p_their()] head off!"))
+			playsound(loc, 'sound/items/jaws_cut.ogg', 50, 1, -1)
+			if(iscarbon(user))
+				var/mob/living/carbon/C = user
+				var/obj/item/bodypart/BP = C.get_bodypart(BODY_ZONE_HEAD)
+				if(BP)
+					BP.drop_limb()
+					playsound(loc,pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg') ,50, 1, -1)
+	return (BRUTELOSS)
+
+/obj/item/jawsoflife/attack(mob/living/carbon/C, mob/user)
+	if (tool_behaviour == TOOL_WIRECUTTER)
+		if(istype(C) && C.handcuffed)
+			user.visible_message(span_notice("[user] cuts [C]'s restraints with [src]!"))
+			qdel(C.handcuffed)
+			return
+		if(istype(C) && C.legcuffed)
+			user.visible_message(span_notice("[user] cuts [C]'s restraints with [src]!"))
+			qdel(C.legcuffed)
+			C.legcuffed = null
+			return
+		//Gainstation Add: We have a choking strand apparently. Adds a check for that.
+		if(C.has_status_effect(STATUS_EFFECT_CHOKINGSTRAND))
+			var/man = C == user ? "your" : "[C]'\s"
+			user.visible_message("<span class='notice'>[user] attempts to remove the durathread strand from around [man] neck.</span>", 
+								"<span class='notice'>You attempt to remove the durathread strand from around [man] neck.</span>")
+			if(do_after(user, 15, null, C))
+				user.visible_message("<span class='notice'>[user] succesfuly removes the durathread strand.</span>",
+									"<span class='notice'>You succesfuly remove the durathread strand.</span>")
+				C.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
+			return
+		//Gainstation End
+		else
+			..()
+	else
+		..()
+
+/obj/item/jawsoflife/proc/transform_crowbar(mob/user)
+	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a prying head."
+	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
+	usesound = 'sound/items/jaws_pry.ogg'
+	hitsound = 'sound/items/jaws_pry.ogg'
+	tool_behaviour = TOOL_CROWBAR
+	icon_state = "jaws_pry"
+	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
+	if (iscyborg(user))
+		to_chat(user,span_notice("Your servos whirr as the cutting head reconfigures into a prying head."))
+	else
+		to_chat(user, span_notice("You attach the pry jaws to [src]."))
+	update_icon()
+
+/obj/item/jawsoflife/proc/transform_cutters(mob/user)
+	attack_verb = list("pinched", "nipped")
+	icon_state = "jaws_cutter"
+	hitsound = 'sound/items/jaws_cut.ogg'
+	usesound = 'sound/items/jaws_cut.ogg'
+	tool_behaviour = TOOL_WIRECUTTER
+	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
+	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a cutting head."
+	if (iscyborg(user))
+		to_chat(user,span_notice("Your servos whirr as the prying head reconfigures into a cutting head."))
+	else
+		to_chat(user, span_notice("You attach the cutting jaws to [src]."))
+	update_icon()
+
+//better handdrill
+/obj/item/handdrill
+	name = "hand drill"
+	desc = "A simple powered hand drill. It's fitted with a screw bit."
+	icon = 'icons/obj/tools.dmi'
+	icon_state = "drill_screw"
+	item_state = "drill"
+	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
+	materials = list(/datum/material/iron=150,/datum/material/silver=50,/datum/material/titanium=25) //done for balance reasons, making them high value for research, but harder to get
+	force = 8 //might or might not be too high, subject to change
+	w_class = WEIGHT_CLASS_SMALL
+	throwforce = 8
+	throw_speed = 2
+	throw_range = 3//it's heavier than a screw driver/wrench, so it does more damage, but can't be thrown as far
+	attack_verb = list("drilled", "screwed", "jabbed","whacked")
+	hitsound = 'sound/items/drill_hit.ogg'
+	usesound = 'sound/items/drill_use.ogg'
+	toolspeed = 0.7
+	tool_behaviour = TOOL_SCREWDRIVER
+	sharpness = SHARP_POINTY
+
+/obj/item/handdrill/attack(mob/living/carbon/M, mob/living/carbon/user)
+	if(!(user.a_intent == INTENT_HARM) && attempt_initiate_surgery(src, M, user))
+		return
+	if(!istype(M))
+		return ..()
+	if(user.zone_selected != BODY_ZONE_PRECISE_EYES && user.zone_selected != BODY_ZONE_HEAD)
+		return ..()
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, span_warning("You don't want to harm [M]!"))
+		return
+	if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
+		M = user
+	return eyestab(M,user)
+
+/obj/item/handdrill/attack_self(mob/user)
+	if (tool_behaviour == TOOL_SCREWDRIVER)
+		transform_wrench(user)
+	else
+		transform_screwdriver(user)
+
+/obj/item/handdrill/suicide_act(mob/user)
+	user.visible_message(span_suicide("[user] is putting [src] to [user.p_their()] temple. It looks like [user.p_theyre()] trying to commit suicide!"))
+	return(BRUTELOSS)
+
+/obj/item/handdrill/proc/transform_wrench(mob/user)
+	desc = "A simple powered hand drill. It's fitted with a bolt bit."
+	icon_state = "drill_bolt"
+	tool_behaviour = TOOL_WRENCH
+	sharpness = SHARP_NONE
+	playsound(get_turf(user),'sound/items/change_drill.ogg',50,1)
+	if (iscyborg(user))
+		to_chat(user,span_notice("Your servos whirr as the drill reconfigures into bolt mode."))
+	else
+		to_chat(user, span_notice("You attach the bolt driver bit to [src]."))
+	update_icon()
+
+/obj/item/handdrill/proc/transform_screwdriver(mob/user)
+	desc = "A simple powered hand drill. It's fitted with a screw bit."
+	icon_state = "drill_screw"
+	tool_behaviour = TOOL_SCREWDRIVER
+	sharpness = SHARP_POINTY
+	playsound(get_turf(user),'sound/items/change_drill.ogg',50,1)
+	if (iscyborg(user))
+		to_chat(user,span_notice("Your servos whirr as the drill reconfigures into screw mode."))
+	else
+		to_chat(user, span_notice("You attach the screw driver bit to [src]."))
+	update_icon()
+
+/obj/item/jawsoflife/jimmy
+	name = "airlock jimmy"
+	desc = "A pump assisted airlock prying jimmy."
+	icon_state = "jimmy"
+	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
+	materials = list(MAT_METAL=400,MAT_SILVER=10,MAT_TITANIUM=80)
+	toolspeed = 0.3 // Starting minimum value. Pump it up by using it up to the max
+	tool_behaviour = TOOL_CROWBAR
+	pryforce = 0.4
+	var/pump_charge = 0
+	var/pump_max = 100
+	var/pump_min = 0
+	var/pump_cost = 50 // the cost to pump best if done in incriments of 25 up to the max
+	var/pump_rate = 25
+	var/is_pumping = FALSE // are we charging at the moment?
+	
+/obj/item/jawsoflife/jimmy/attack_self(mob/user) // airlock jimmy can't switch tool modes back to cutters.
+	if(user)
+		pump(user)
+		show_gage(user)
+	
+/obj/item/jawsoflife/jimmy/proc/pump(mob/user)
+	if(pump_charge >= pump_max && user)
+		to_chat(user,"[src] is fully pumped.")
+	else
+		if(!is_pumping)
+			var/old_value = pump_charge
+			is_pumping = TRUE
+			pump_charge = (pump_charge + pump_rate) > pump_max ? pump_max : pump_charge + pump_rate
+			if(old_value != pump_charge)
+				playsound(src, 'sound/items/jimmy_pump.ogg', 100, TRUE) // no need you pump; didn't pump but instead looked at the gage
+				addtimer(CALLBACK(src, .proc/pump_cooldown), 5) // cooldown between pumps
+				addtimer(CALLBACK(src, .proc/pump_powerdown), 300) // lose gained power after 30 seconds
+	return
+
+/obj/item/jawsoflife/jimmy/proc/pump_powerdown(mob/user)
+	if((pump_charge - 25) >= 0)
+		pump_charge = pump_charge - 25
+	return
+
+/obj/item/jawsoflife/jimmy/proc/show_gage(mob/user)
+	var/emag_givaway_flavor = ""
+	if(pump_charge > 101)
+		emag_givaway_flavor = pick("somehow","unironically","ironically","actually","maybe")
+	to_chat(user,"[src]'s pressure gage [emag_givaway_flavor] reads [pump_charge]%")
+
+/obj/item/jawsoflife/jimmy/proc/pump_cooldown()
+	is_pumping = FALSE
+
+/obj/item/jawsoflife/jimmy/emag_act(mob/user)
+	if(obj_flags & EMAGGED)
+		to_chat(user, span_warning("Nothing new seems to happen when you swipe the emag."))
+		return
+	to_chat(user, span_notice("You swipe the emag on [src]'s pressure gage' enabling you to pump more pressure. "))
+	obj_flags |= EMAGGED
+	pump_max = 150
+	pump_cost = 75
+	. = ..()
+
+/obj/item/jawsoflife/jimmy/examine(mob/user)
+	. = ..()
+	if(obj_flags & EMAGGED)
+		. += span_danger("The pressure gage has been tampered with.")
+	if(user)
+		show_gage(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes all (most) belts bulky in size. This is a change bigger codebases made since it makes toolbelts a more dedicative item opposed to a weird box sidegrade. Toolbelts have been upgraded to allow storing RCDs, RPDs and other larger items. They also have a bit more storage space. Additionally, Durathread toolbelts have ~50% more space and ~40% more total items, to keep them as a strong upgrade. I might come back to this later and rebalance it. 
Did you know durathread toolbelts are like a combination of all 3 major department toolbelts? The description of the durathread toolbelt has been changed to reflect this, but it was a thing even before this PR.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes toolbelts a storage upgrade that's not in the same class as boxes. You gotta think about how you hold your stuffs now or someth,
also durathread toolbelts are busted op currently and that fixes that IG
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Tweaked the max amount of items toolbelts can carry from 7 to 11
tweak: Tweaked the max_combined_weight of toolbelts from  14 to 24
tweak: Tweaked the max amount of items durathread toolbelts can carry from 14 to 20
tweak: Tweaked the max_combined_weight of durathread toolbelts from  32 to 36
tweak: Changed the durathread toolbelt to reflect it's storage capabilities, and because it's original description isnt a special perk anymore.
tweak: RPDs and RCDs can now be slotted into your belt slot on their own. I stole this one from TG and am sliding it in here because they did it in their belt resize pr. Teehee.
balance: Rebalanced belt size to be bulky.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
