### PR TITLE
Xenobiology nerf

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -79,6 +79,7 @@
 #define TRAIT_MONKEYLIKE		"monkeylike" //sets IsAdvancedToolUser to FALSE
 #define TRAIT_PACIFISM			"pacifism"
 #define TRAIT_IGNORESLOWDOWN	"ignoreslow"
+#define TRAIT_IMMUTABLE_SLOW	"immutableslow" //Cannot become faster
 #define TRAIT_GOTTAGOFAST		"fast"
 #define TRAIT_GOTTAGOREALLYFAST	"2fast"
 #define TRAIT_DEATHCOMA			"deathcoma" //Causes death-like unconsciousness

--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -134,14 +134,12 @@ Slimecrossing Armor
 	flags_inv = NONE
 	obj_flags = IMMUTABLE_SLOW
 	slowdown = 4
-	var/hit_reflect_chance = 10 // Citadel Change: because 40% chance of bouncing lasers back into peoples faces isn't good.
-	armor = list("melee" = 70, "bullet" = 70, "laser" = 40, "energy" = 40, "bomb" = 80, "bio" = 80, "rad" = 80, "fire" = 70, "acid" = 90) //Citadel Change to avoid immortal Xenobiologists.
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 40, "energy" = 40, "bomb" = 60, "bio" = 60, "rad" = 60, "fire" = 60, "acid" = 60) //GS change, lower resistances across the field, No reflect chances. The shield does that.
 
-/obj/item/clothing/suit/armor/heavy/adamantine/IsReflect(def_zone)
-	if(def_zone in list(BODY_ZONE_CHEST, BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG) && prob(hit_reflect_chance))
-		return TRUE
-	else
-		return FALSE
+/obj/item/clothing/suit/armor/heavy/adamantine/equipped(mob/living/carbon/human/user, slot) //Gives you a trait to prevent increasing speed.
+	. = ..()
+	if(slot == SLOT_WEAR_SUIT)
+		ADD_TRAIT(user, TRAIT_IMMUTABLE_SLOW, "immutableslow_[REF(src)]")
 
 /obj/structure/light_prism/spectral
 	name = "spectral light prism"

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -765,8 +765,10 @@ datum/status_effect/stabilized/blue/on_remove()
 	colour = "red"
 
 /datum/status_effect/stabilized/red/on_apply()
-	owner.ignore_slowdown("slimestatus")
-	return ..()
+	if(HAS_TRAIT(owner, TRAIT_IMMUTABLE_SLOW))
+		return ..()
+	else
+		owner.ignore_slowdown("slimestatus")
 
 /datum/status_effect/stabilized/red/on_remove()
 	owner.unignore_slowdown("slimestatus")
@@ -915,6 +917,7 @@ datum/status_effect/stabilized/blue/on_remove()
 
 /datum/status_effect/stabilized/lightpink/on_apply()
 	ADD_TRAIT(owner, TRAIT_GOTTAGOFAST,"slimestatus")
+	ADD_TRAIT(owner, TRAIT_PACIFISM,"slimestatus")
 	return ..()
 
 /datum/status_effect/stabilized/lightpink/tick()
@@ -926,6 +929,7 @@ datum/status_effect/stabilized/blue/on_remove()
 
 /datum/status_effect/stabilized/lightpink/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_GOTTAGOFAST,"slimestatus")
+	REMOVE_TRAIT(owner, TRAIT_PACIFISM,"slimestatus")
 
 /datum/status_effect/stabilized/adamantine
 	id = "stabilizedadamantine"

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -24,13 +24,13 @@ Regenerative extracts:
 		to_chat(user, "<span class='warning'>[src] will not work on the dead!</span>")
 		return
 	if(H != user)
-		user.visible_message("<span class='notice'>[user] crushes the [src] over [H], the milky goo quickly regenerating all of [H.p_their()] injuries!</span>",
+		user.visible_message("<span class='notice'>[user] crushes the [src] over [H], the milky goo quickly seeping into [H.p_their()] skin!</span>",
 			"<span class='notice'>You squeeze the [src], and it bursts over [H], the milky goo regenerating [H.p_their()] injuries.</span>")
 	else
-		user.visible_message("<span class='notice'>[user] crushes the [src] over [user.p_them()]self, the milky goo quickly regenerating all of [user.p_their()] injuries!</span>",
-			"<span class='notice'>You squeeze the [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates your injuries!</span>")
+		user.visible_message("<span class='notice'>[user] crushes the [src] over [user.p_them()]self, the milky goo quickly seeping into [user.p_their()] skin!</span>",
+			"<span class='notice'>You squeeze the [src], and it bursts in your hand, splashing you with milky goo which seeps into your skin!</span>")
 	core_effect_before(H, user)
-	H.revive(full_heal = 1)
+	target.reagents.add_reagent(/datum/reagent/medicine/regen_jelly,30) //TODO Make these stronger, No aheals but I'll make a new medicine for these to add that heals faster.
 	core_effect(H, user)
 	playsound(target, 'sound/effects/splat.ogg', 40, 1)
 	qdel(src)
@@ -51,7 +51,7 @@ Regenerative extracts:
 	colour = "purple"
 
 /obj/item/slimecross/regenerative/purple/core_effect(mob/living/target, mob/user)
-	target.reagents.add_reagent(/datum/reagent/medicine/regen_jelly,10)
+	target.reagents.add_reagent(/datum/reagent/medicine/neo_jelly,15) //Varies what it applies so you get two powerful healing chems at once. 
 
 /obj/item/slimecross/regenerative/blue
 	colour = "blue"
@@ -148,10 +148,10 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/sepia
 	colour = "sepia"
-
-/obj/item/slimecross/regenerative/sepia/core_effect(mob/living/target, mob/user)
+/*
+/obj/item/slimecross/regenerative/sepia/core_effect(mob/living/target, mob/user) //Disabling this for the timebeing, Timestop is literally a wizard spell, this shouldn't exist.
 	new /obj/effect/timestop(get_turf(target), 2, 50, list(user,target))
-
+*/
 /obj/item/slimecross/regenerative/cerulean
 	colour = "cerulean"
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -845,7 +845,7 @@
 		return
 	if(isitem(C))
 		var/obj/item/I = C
-		if(I.slowdown <= 0 || I.obj_flags & IMMUTABLE_SLOW)
+		if(I.slowdown <= 0 || I.obj_flags == IMMUTABLE_SLOW)
 			to_chat(user, "<span class='warning'>The [C] can't be made any faster!</span>")
 			return ..()
 		I.slowdown = 0

--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -44,6 +44,9 @@
 		else if(M.size_multiplier > max_size)
 			to_chat(M, "<span class='warning'>You are too big to operate something like this!</span>")
 			unbuckle_mob(M)
+		else if(HAS_TRAIT(M, TRAIT_IMMUTABLE_SLOW))
+			to_chat(M, "<span class='warning'>Your armor is too heavy to operate something like this!</span>")
+			unbuckle_mob(M)
 	return ..()
 
 /obj/vehicle/ridden/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
Small nerfs to Xenobio, More will come

Nerfs adamantine armor to work as originally intended and reduces it's armor values further. (No more elite syndicate hardsuits)
Nerfs regenerative extracts (No more aheals, they instead add medicine too you on use TODO: Make a unique medicine for them to use since they should still be good)
Nerfs Stable Light Pink (Biggest offender is this thing. Makes you a pacifist when active, TG Change)