### PR TITLE
Xenobiology Nerf Round 2

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1521,3 +1521,40 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 	name = "Synthi-Sanguirite"
 	description = "A synthetic coagulant used to help bleeding wounds clot faster. Not quite as effective as name brand Sanguirite, especially on patients with lots of cuts."
 	clot_coeff_per_wound = 0.8
+
+//Chem for regen extracts to use
+/datum/reagent/medicine/pure_regen_jelly
+	name = "Pure Regenerative Jelly"
+	description = "Very pure form of regenerative jelly that regenerates all types of damage rapidly, without harming slime anatomy."
+	reagent_state = LIQUID
+	color = "#91D865"
+	metabolization_rate = 0.25 * REAGENTS_METABOLISM
+	taste_description = "jelly"
+	can_synth = FALSE
+
+/datum/reagent/medicine/pure_regen_jelly/on_mob_life(mob/living/carbon/M)
+	M.adjustBruteLoss(-5*REM, 0)
+	M.adjustFireLoss(-5*REM, 0)
+	M.adjustOxyLoss(-5*REM, 0)
+	M.adjustToxLoss(-5*REM, 0, TRUE) //heals TOXINLOVERs
+	. = 1
+	..()
+
+/datum/reagent/medicine/pure_neo_jelly
+	name = "Pure Neo Jelly"
+	description = "Pure Neo-Jelly that rapidly heals all damage."
+	reagent_state = LIQUID
+	metabolization_rate = 0.25 * REAGENTS_METABOLISM
+	color = "#91D865"
+	taste_description = "jelly"
+	can_synth = FALSE
+
+/datum/reagent/medicine/pure_neo_jelly/on_mob_life(mob/living/carbon/M)
+	M.adjustBruteLoss(-1*REM, 0)
+	M.adjustFireLoss(-1*REM, 0)
+	M.adjustOxyLoss(-1*REM, 0)
+	M.adjustToxLoss(-1*REM, 0, TRUE) //heals TOXINLOVERs
+	M.heal_bodypart_damage(3,3)
+	. = 1
+	..()
+

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -491,6 +491,8 @@ datum/status_effect/rebreathing/tick()
 
 /datum/status_effect/stabilized/purple/tick()
 	var/is_healing = FALSE
+	if(owner.nutrition <= NUTRITION_LEVEL_STARVING) //No healing if you don't eat
+		return..()
 	if(owner.getBruteLoss() > 0)
 		owner.adjustBruteLoss(-0.2)
 		is_healing = TRUE
@@ -503,6 +505,7 @@ datum/status_effect/rebreathing/tick()
 	if(is_healing)
 		examine_text = "<span class='warning'>SUBJECTPRONOUN is regenerating slowly, purplish goo filling in small injuries!</span>"
 		new /obj/effect/temp_visual/heal(get_turf(owner), "#FF0000")
+		owner.nutrition -= 5 //Drains nutrition to heal. Idea is to make it seem like it's just speeding up natural regeneration significantly
 	else
 		examine_text = null
 	..()
@@ -544,8 +547,8 @@ datum/status_effect/stabilized/blue/on_remove()
 /datum/status_effect/stabilized/yellow
 	id = "stabilizedyellow"
 	colour = "yellow"
-	var/cooldown = 10
-	var/max_cooldown = 10
+	var/cooldown = 30
+	var/max_cooldown = 30
 	examine_text = "<span class='warning'>Nearby electronics seem just a little more charged wherever SUBJECTPRONOUN goes.</span>"
 
 /datum/status_effect/stabilized/yellow/tick()
@@ -601,6 +604,7 @@ datum/status_effect/stabilized/blue/on_remove()
 	colour = "dark blue"
 
 /datum/status_effect/stabilized/darkblue/tick()
+	owner.adjust_bodytemperature(min(-1.5)) //Makes you colder, you are soaking wet after all
 	if(owner.fire_stacks > 0 && prob(80))
 		owner.fire_stacks--
 		if(owner.fire_stacks <= 0)

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -30,7 +30,7 @@ Regenerative extracts:
 		user.visible_message("<span class='notice'>[user] crushes the [src] over [user.p_them()]self, the milky goo quickly seeping into [user.p_their()] skin!</span>",
 			"<span class='notice'>You squeeze the [src], and it bursts in your hand, splashing you with milky goo which seeps into your skin!</span>")
 	core_effect_before(H, user)
-	target.reagents.add_reagent(/datum/reagent/medicine/regen_jelly,30) //TODO Make these stronger, No aheals but I'll make a new medicine for these to add that heals faster.
+	target.reagents.add_reagent(/datum/reagent/medicine/pure_regen_jelly,5) //No instant aheals. Gives medicine instead, extremely fast acting and very powerful. But not instant.
 	core_effect(H, user)
 	playsound(target, 'sound/effects/splat.ogg', 40, 1)
 	qdel(src)
@@ -51,7 +51,7 @@ Regenerative extracts:
 	colour = "purple"
 
 /obj/item/slimecross/regenerative/purple/core_effect(mob/living/target, mob/user)
-	target.reagents.add_reagent(/datum/reagent/medicine/neo_jelly,15) //Varies what it applies so you get two powerful healing chems at once. 
+	target.reagents.add_reagent(/datum/reagent/medicine/pure_neo_jelly,5) //Varies what it applies so you get two powerful healing chems at once since Purples are all about healing.
 
 /obj/item/slimecross/regenerative/blue
 	colour = "blue"

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -21,7 +21,7 @@
 	return TRUE
 /datum/surgery_step/lobotomize
 	name = "perform lobotomy"
-	implements = list(TOOL_SCALPEL = 85, /obj/item/melee/transforming/energy/sword = 55, /obj/item/kitchen/knife = 35,
+	implements = list(TOOL_SCALPEL = 90, /obj/item/melee/transforming/energy/sword = 55, /obj/item/kitchen/knife = 35,
 		/obj/item/shard = 25, /obj/item = 20)
 	time = 100
 /datum/surgery_step/lobotomize/tool_check(mob/user, obj/item/tool)
@@ -43,11 +43,11 @@
 		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
 	switch(rand(1,4))//Now let's see what hopefully-not-important part of the brain we cut off
 		if(1)
-			target.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_MAGIC)
+			target.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_SURGERY)
 		if(2)
-			target.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_MAGIC)
+			target.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_SURGERY)
 		if(3)
-			target.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_MAGIC)
+			target.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_SURGERY)
 	return TRUE
 
 /datum/surgery_step/lobotomize/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -59,11 +59,11 @@
 		B.applyOrganDamage(80)
 		switch(rand(1,3))
 			if(1)
-				target.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_MAGIC)
+				target.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_LOBOTOMY)
 			if(2)
-				target.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_MAGIC)
+				target.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_LOBOTOMY)
 			if(3)
-				target.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_MAGIC)
+				target.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_LOBOTOMY)
 	else
 		user.visible_message("<span class='warning'>[user] suddenly notices that the brain [user.p_they()] [user.p_were()] working on is not there anymore.", "<span class='warning'>You suddenly notice that the brain you were working on is not there anymore.</span>")
 	return FALSE


### PR DESCRIPTION
Second round of nerfs to Xenobio

Adds a new chem for the regen extracts to use. Pure Regen Jelly and Pure Neo Jelly. Cannot be made in any way, heals rapidly and metabolizes slowly. 

Stable Purples cost hunger when in use now, high nutrition cost for low healing but Xenobiologists can produce food infinitely, and also just ask the chef for a framewrecker. They will stop healing you if you are starving

Yellow Stables now have a 30 second delay instead of 10 seconds, as before it could lead to infinite ammo laser guns really easily. 

Stable Dark Blue passively makes you colder now. You are soaking wet with them equipped after all and their main gimmick is killing fires automatically, which tend to make you hot.